### PR TITLE
Fix migration order and foreign keys and add destroy all to rake

### DIFF
--- a/db/migrate/20210413020518_create_items.rb
+++ b/db/migrate/20210413020518_create_items.rb
@@ -4,7 +4,7 @@ class CreateItems < ActiveRecord::Migration[5.2]
       t.string :name
       t.string :description
       t.integer :unit_price
-      t.integer :merchant_id, foreign_key: true
+      t.references :merchant, foreign_key: true
       t.datetime :created_at
       t.datetime :updated_at
     end

--- a/db/migrate/20210413020637_create_invoices.rb
+++ b/db/migrate/20210413020637_create_invoices.rb
@@ -1,8 +1,8 @@
 class CreateInvoices < ActiveRecord::Migration[5.2]
   def change
     create_table :invoices do |t|
-      t.integer :customer_id, foreign_key: true
       t.integer :status
+      t.references :customer, foreign_key: true
       t.datetime :created_at
       t.datetime :updated_at
     end

--- a/db/migrate/20210413020721_create_transactions.rb
+++ b/db/migrate/20210413020721_create_transactions.rb
@@ -1,10 +1,10 @@
 class CreateTransactions < ActiveRecord::Migration[5.2]
   def change
     create_table :transactions do |t|
-      t.integer :invoice_id, foreign_key: true
       t.string :credit_card_number
       t.datetime :credit_card_expiration_date
       t.integer :result
+      t.references :invoice, foreign_key: true
       t.datetime :created_at
       t.datetime :updated_at
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,19 +35,21 @@ ActiveRecord::Schema.define(version: 2021_04_14_000521) do
   end
 
   create_table "invoices", force: :cascade do |t|
-    t.integer "customer_id"
     t.integer "status"
+    t.bigint "customer_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["customer_id"], name: "index_invoices_on_customer_id"
   end
 
   create_table "items", force: :cascade do |t|
     t.string "name"
     t.string "description"
     t.integer "unit_price"
-    t.integer "merchant_id"
+    t.bigint "merchant_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["merchant_id"], name: "index_items_on_merchant_id"
   end
 
   create_table "merchants", force: :cascade do |t|
@@ -57,14 +59,18 @@ ActiveRecord::Schema.define(version: 2021_04_14_000521) do
   end
 
   create_table "transactions", force: :cascade do |t|
-    t.integer "invoice_id"
     t.string "credit_card_number"
     t.datetime "credit_card_expiration_date"
     t.integer "result"
+    t.bigint "invoice_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["invoice_id"], name: "index_transactions_on_invoice_id"
   end
 
   add_foreign_key "invoice_items", "invoices"
   add_foreign_key "invoice_items", "items"
+  add_foreign_key "invoices", "customers"
+  add_foreign_key "items", "merchants"
+  add_foreign_key "transactions", "invoices"
 end

--- a/lib/tasks/all.rake
+++ b/lib/tasks/all.rake
@@ -1,7 +1,16 @@
 require 'csv'
 
 namespace :csv_load do
+  desc "Seed database with all csv files"
   task all: :environment do
+    # Reset database
+    InvoiceItem.destroy_all
+    Transaction.destroy_all
+    Item.destroy_all
+    Invoice.destroy_all
+    Customer.destroy_all
+    Merchant.destroy_all
+
     CSV.foreach("db/data/merchants.csv", { encoding: "UTF-8", headers: true, header_converters: :symbol, converters: :all}) do |row|
       Merchant.create(row.to_hash)
     end
@@ -14,16 +23,16 @@ namespace :csv_load do
       Invoice.create(row.to_hash)
     end
 
-    CSV.foreach("db/data/transactions.csv", { encoding: "UTF-8", headers: true, header_converters: :symbol, converters: :all}) do |row|
-      Transaction.create(row.to_hash)
-    end
-
     CSV.foreach("db/data/items.csv", { encoding: "UTF-8", headers: true, header_converters: :symbol, converters: :all}) do |row|
       Item.create(row.to_hash)
     end
 
     CSV.foreach("db/data/invoice_items.csv", { encoding: "UTF-8", headers: true, header_converters: :symbol, converters: :all}) do |row|
       InvoiceItem.create(row.to_hash)
+    end
+
+    CSV.foreach("db/data/transactions.csv", { encoding: "UTF-8", headers: true, header_converters: :symbol, converters: :all}) do |row|
+      Transaction.create(row.to_hash)
     end
   end
 end


### PR DESCRIPTION
Changes made:
- Add missing foreign keys (to invoices, items, transactions)
- Fix migration order
- Add destroy_alls to csv_load
- Fix order of destroy_alls